### PR TITLE
handle base64 conversion based on environment

### DIFF
--- a/example/node/import.mjs
+++ b/example/node/import.mjs
@@ -6,7 +6,7 @@ dotenv.config();
 const endpoint = process.env.LRS_ENDPOINT || "";
 const username = process.env.LRS_USERNAME || "";
 const password = process.env.LRS_PASSWORD || "";
-const auth = `Basic ${Buffer.from(username + ":" + password, "binary").toString("base64")}`;
+const auth = XAPI.toBasicAuth(username, password);
 const xapi = new XAPI(endpoint, auth);
 
 xapi.getAbout().then((result) => {

--- a/example/node/require.js
+++ b/example/node/require.js
@@ -5,7 +5,7 @@ require("dotenv").config();
 const endpoint = process.env.LRS_ENDPOINT || "";
 const username = process.env.LRS_USERNAME || "";
 const password = process.env.LRS_PASSWORD || "";
-const auth = `Basic ${Buffer.from(username + ":" + password, "binary").toString("base64")}`;
+const auth = XAPI.toBasicAuth(username, password);
 const xapi = new XAPI(endpoint, auth);
 
 xapi.getAbout().then((result) => {

--- a/src/XAPI.e2e.spec.ts
+++ b/src/XAPI.e2e.spec.ts
@@ -19,7 +19,7 @@ interface Encoder {
 const endpoint: string = process.env.LRS_ENDPOINT || "";
 const username: string = process.env.LRS_USERNAME || "";
 const password: string = process.env.LRS_PASSWORD || "";
-const auth: string = `Basic ${btoa(username + ":" + password)}`;
+const auth: string = `Basic ${XAPI.toBasicAuth(username, password)}`;
 const xapi: XAPI = new XAPI(endpoint, auth);
 
 const testAgent: Agent = {

--- a/src/XAPI.e2e.spec.ts
+++ b/src/XAPI.e2e.spec.ts
@@ -19,7 +19,7 @@ interface Encoder {
 const endpoint: string = process.env.LRS_ENDPOINT || "";
 const username: string = process.env.LRS_USERNAME || "";
 const password: string = process.env.LRS_PASSWORD || "";
-const auth: string = `Basic ${XAPI.toBasicAuth(username, password)}`;
+const auth: string = XAPI.toBasicAuth(username, password);
 const xapi: XAPI = new XAPI(endpoint, auth);
 
 const testAgent: Agent = {

--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -54,7 +54,7 @@ export default class XAPI {
       "X-Experience-API-Version": version,
       "Content-Type": "application/json",
       // No Authorization Process and Requirements -  https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#no-authorization-process-and-requirements
-      Authorization: auth ? auth : `Basic ${toBasicAuth("", "")}`,
+      Authorization: auth ? auth : toBasicAuth("", ""),
     };
   }
 

--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -54,7 +54,7 @@ export default class XAPI {
       "X-Experience-API-Version": version,
       "Content-Type": "application/json",
       // No Authorization Process and Requirements -  https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#no-authorization-process-and-requirements
-      Authorization: auth ? auth : `Basic ${btoa(":")}`,
+      Authorization: auth ? auth : `Basic ${toBasicAuth("", "")}`,
     };
   }
 

--- a/src/helpers/toBasicAuth.spec.ts
+++ b/src/helpers/toBasicAuth.spec.ts
@@ -7,15 +7,19 @@ test("converts username and password into Basic Auth header", () => {
     ["Mr}VBHb^)zyc39`<", '?YrAhvP{}"s94:%%'],
   ];
 
-  const manualFunction = (pair) =>
+  const bufferFunction = (pair) =>
     `Basic ${Buffer.from(pair[0] + ":" + pair[1], "binary").toString(
       "base64"
     )}`;
+  const btoaFunction = (pair) => `Basic ${btoa(`${pair[0]}:${pair[1]}`)}`;
   const helperFunction = (pair) => toBasicAuth(pair[0], pair[1]);
 
-  const results = pairs.map(
-    (pair) => manualFunction(pair) === helperFunction(pair)
-  );
+  const results = pairs.map((pair) => {
+    return (
+      bufferFunction(pair) === helperFunction(pair) &&
+      btoaFunction(pair) === helperFunction(pair)
+    );
+  });
 
   return expect(results).not.toContain(false);
 });

--- a/src/helpers/toBasicAuth.ts
+++ b/src/helpers/toBasicAuth.ts
@@ -1,5 +1,9 @@
 export function toBasicAuth(username: string, password: string): string {
-  return `Basic ${Buffer.from(username + ":" + password, "binary").toString(
-    "base64"
-  )}`;
+  const credentials = `${username}:${password}`;
+  if (typeof window !== "undefined" && window.btoa) {
+    return `Basic ${btoa(credentials)}`;
+  } else if (typeof Buffer !== "undefined") {
+    return `Basic ${Buffer.from(credentials, "binary").toString("base64")}`;
+  }
+  throw new Error("Environment does not support base64 conversion.");
 }


### PR DESCRIPTION
I tried out a few different things and ultimately decided it's just best to keep things simple. This works well for both worlds by using the native method depending on the environment. I updated the node based examples too, which seemed to pass the test well.